### PR TITLE
Add purpose field to A/B Street input

### DIFF
--- a/src/demand_to_abst_scenario.py
+++ b/src/demand_to_abst_scenario.py
@@ -38,7 +38,8 @@ def main():
                     'destination': {
                         'Position': destination
                     },
-                    'mode': 'Drive'
+                    'mode': 'Drive',
+                    'purpose': 'Work'
                 }]
             })
 


### PR DESCRIPTION
https://a-b-street.github.io/docs/dev/formats/scenarios.html now requires `purpose`. The field is ignored except in the UI, but in the future, it may affect a driver's willingness to pay tolls, for instance.